### PR TITLE
docs: Fix antigen installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ zplug "spaceship-prompt/spaceship-vi-mode"
 ### [antigen]
 
 ```zsh
-antigen bundle "spaceship-prompt/spaceship-vi-mode"
+antigen bundle spaceship-prompt/spaceship-vi-mode@main
 ```
 
 ### [antibody]


### PR DESCRIPTION
#### Description

Antigen, [by default](https://github.com/zsh-users/antigen/blob/64de2dcd95d6a8e879cd2244c763d99f0144e78e/src/lib/ensure-repo.zsh#L42), tries to fetch `master`, consequently, it fails with this bundle since the default branch is `main`.
