### PR TITLE
fix: perform refresh on any vi_mode changes

### DIFF
--- a/spaceship-vi-mode.plugin.zsh
+++ b/spaceship-vi-mode.plugin.zsh
@@ -47,7 +47,7 @@ spaceship_vi_mode() {
 
 # Temporarily switch to vi-mode
 spaceship_vi_mode_enable() {
-  function zle-keymap-select() { zle reset-prompt ; zle -R }
+  function zle-keymap-select() { spaceship::core::refresh_section "vi_mode" ; zle .reset-prompt && zle -R }
   zle -N zle-keymap-select
   bindkey -v
 }


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR.

-->

#### Description

As mentioned in #2 once spaceship-prompt was updated to v4 and vi-mode was separated it stopped updating even when `eval spaceship_vi_mode_enable` was present in the .zshrc file.  This change adds an explicit trigger to refresh the vi-mode section whenever there is a change to the vi-mode.  This requires user to have the previously mentioned line present in their .zshrc as is mentioned in the README.md file of this repository.

