### PR TITLE
docs: adds spaceship_vi_mode_enable to prompt init

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ For initializing prompt system add this to your `.zshrc`:
 
 ```zsh title=".zshrc"
 source "~/.zsh/spaceship-vi-mode/spaceship-vi-mode.plugin.zsh"
+spaceship_vi_mode_enable
 ```
 
 ## Usage


### PR DESCRIPTION
<!-- Thanks for your pull-request!

Please, make sure you've read `CONTRIBUTING.md` before submitting this PR.

-->

#### Description

I updated the documentation to add spaceship_vi_mode_enable to the prompt initialization section. I had difficulty enabling vi mode initially and found the solution in an issue in the core repository. This change clarifies how to enable vi mode within the prompt configuration. Adding this to the documentation may help others who run into the same problem.

#### Screenshot

<!-- Please, attach a screenshot, if possible.

![screenshot](url) -->
